### PR TITLE
fix(truncateLargeString): truncate binary strings properly

### DIFF
--- a/lib/converters/yql-to-unipika.js
+++ b/lib/converters/yql-to-unipika.js
@@ -136,11 +136,45 @@
             return node;
         }
 
+        function truncateBase64(text, maxBytes) {
+            // divide into 24-bit groups aka 3 bytes or 4 base64-chars
+            // and append the rest with padding
+        
+            var fullGroups = Math.min(
+                Math.floor(maxBytes / 3),
+                Math.ceil(text.length / 4)
+            );
+        
+            var headChars = fullGroups * 4;
+        
+            var restBytes = Math.min(
+                maxBytes - fullGroups * 3,
+                text.length - headChars
+            );
+        
+            var head = text.substr(0, headChars);
+        
+            if(restBytes == 1) {
+                return head + text.substr(headChars, 2) + '==';
+            } else if(restBytes == 2) {
+                return head + text.substr(headChars, 3) + '=';
+            }
+        
+            return head;
+        }
+
         function truncateLargeString(node) {
-            if (settings.maxStringSize > 0 && node.$value && node.$value.length > settings.maxStringSize &&
-                !(node.$tag || node.$binary)) {
-                node.$value = node.$value.substr(0, settings.maxStringSize);
-                return wrapIncomplete(node, true);
+            if (settings.maxStringSize > 0 && node.$value) {
+                if(!node.$binary && !node.$tag && node.$value.length > settings.maxStringSize) {
+                    node.$value = node.$value.substr(0, settings.maxStringSize);
+                    return wrapIncomplete(node, true);
+                }
+
+                // 0.75 - base64 chars to bytes ratio
+                if(node.$binary && !node.$tag && node.$value.length * 0.75 > settings.maxStringSize) {
+                    node.$value = truncateBase64(node.$value, settings.maxStringSize);
+                    return wrapIncomplete(node, true);
+                }
             }
             return node;
         }

--- a/test/converters/yql-to-unipika.test.ts
+++ b/test/converters/yql-to-unipika.test.ts
@@ -656,5 +656,62 @@ describe("converters", function () {
       };
       expect(yqlToYson([data, dataType], { maxListSize: 2 })).toEqual(result);
     });
+
+    test("Regular strings get truncated", function () {
+      var text = "We're no strangers to love\nYou know the rules and so do I\nA full commitment's what I'm thinking of\nYou wouldn't get this from any other guy";
+      var maxStringSize = 25;
+
+      var dataType = ["DataType", "String"];
+      var data = text;
+
+      var actual = yqlToYson([data, dataType], {maxStringSize: maxStringSize});
+
+      expect(actual.$value).toEqual("We're no strangers to lov");
+      expect(actual.$value.length).toEqual(25);
+    });
+
+    describe("Binary strings get truncated", function () {
+      test("with no tail bytes in base64", function () {
+        var text = "We're no strangers to love\nYou know the rules and so do I\nA full commitment's what I'm thinking of\nYou wouldn't get this from any other guy";
+        var base64 = btoa(text);
+        var maxStringSize = 24;
+  
+        var dataType = ["DataType", "String"];
+        var data = [base64];
+  
+        var yson = yqlToYson([data, dataType], {maxStringSize: maxStringSize});
+  
+        expect(atob(yson.$value)).toEqual("We're no strangers to lo");
+        expect(atob(yson.$value).length).toEqual(24);
+      });
+
+      test("with 1 tail byte in base64", function () {
+        var text = "We're no strangers to love\nYou know the rules and so do I\nA full commitment's what I'm thinking of\nYou wouldn't get this from any other guy";
+        var base64 = btoa(text);
+        var maxStringSize = 25;
+  
+        var dataType = ["DataType", "String"];
+        var data = [base64];
+  
+        var yson = yqlToYson([data, dataType], {maxStringSize: maxStringSize});
+  
+        expect(atob(yson.$value)).toEqual("We're no strangers to lov");
+        expect(atob(yson.$value).length).toEqual(25);
+      });
+
+      test("with 2 tail bytes in base64", function () {
+        var text = "We're no strangers to love\nYou know the rules and so do I\nA full commitment's what I'm thinking of\nYou wouldn't get this from any other guy";
+        var base64 = btoa(text);
+        var maxStringSize = 26;
+  
+        var dataType = ["DataType", "String"];
+        var data = [base64];
+  
+        var yson = yqlToYson([data, dataType], {maxStringSize: maxStringSize});
+  
+        expect(atob(yson.$value)).toEqual("We're no strangers to love");
+        expect(atob(yson.$value).length).toEqual(26);
+      });
+    });
   });
 });


### PR DESCRIPTION
we're getting giant hex arrays rendered that lag and look messy, so here's fix